### PR TITLE
Delete cascade on SQL script

### DIFF
--- a/scripts/db_script.txt
+++ b/scripts/db_script.txt
@@ -29,9 +29,11 @@ SELECT * FROM review;
 ALTER TABLE rating
 ADD CONSTRAINT fk_rating_book
 FOREIGN KEY (bookId)
-REFERENCES book(id);
+REFERENCES book(id)
+ON DELETE CASCADE;
 
 ALTER TABLE review
 ADD CONSTRAINT fk_review_book
 FOREIGN KEY (bookId)
-REFERENCES book(id);
+REFERENCES book(id)
+ON DELETE CASCADE;


### PR DESCRIPTION
This is to ensure deletion of book will also remove associated `review` and `rating` of the book. this is in line with the rubric asking to remove associated data.